### PR TITLE
Fix Messages Bundle Identifier for latest versions of macOS (11.0+)

### DIFF
--- a/Jared/PermissionsHelper.swift
+++ b/Jared/PermissionsHelper.swift
@@ -15,7 +15,12 @@ class PermissionsHelper {
     }
     
     static func canSendMessages(shouldPrompt: Bool = false) -> AutomationPermissionState {
-        let target = NSAppleEventDescriptor(bundleIdentifier: "com.apple.iChat")
+        let target: NSAppleEventDescriptor
+        if #available(OSX 11.0, *) {
+            target = NSAppleEventDescriptor(bundleIdentifier: "com.apple.MobileSMS")
+        } else {
+            target = NSAppleEventDescriptor(bundleIdentifier: "com.apple.iChat")
+        }
         if #available(OSX 10.14, *) {
             let permission = AEDeterminePermissionToAutomateTarget(target.aeDesc, typeWildCard, typeWildCard, shouldPrompt)
             var permissionEnum: AutomationPermissionState


### PR DESCRIPTION
It looks like starting with macOS Big Sur, the bundle id for Messages.app has changed from `com.apple.iChat` to `com.apple.MobileSMS`