### PR TITLE
Replace SQLite polling with WAL file-system watcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,107 @@
+# AGENTS.md — Jared iMessage Bot
+
+## Build & Test
+
+**Build/run**: Open `Jared.xcodeproj` in Xcode. There are four schemes:
+- `JaredUI` — the main macOS app
+- `JaredFramework` — the shared framework (build this first if JaredFramework module errors appear)
+- `JaredTests` — unit tests
+- `JaredUITests` — UI tests
+
+**Run tests from CLI** (as used in CI):
+```
+xcodebuild -project Jared.xcodeproj -scheme JaredTests test ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+```
+
+**"No such module 'JaredFramework'" errors**: This is normal when Xcode hasn't built the framework target yet. Build the `JaredFramework` scheme first, then build `Jared`/`JaredTests`. These LSP errors are stale and not real compile failures.
+
+## Architecture Overview
+
+Jared is a macOS iMessage bot. It polls the local Messages SQLite database (`~/Library/Messages/chat.db`) every ~5 seconds for new rows, constructs `Message` objects, and routes them through a plugin system.
+
+**Data flow:**
+```
+DatabaseHandler (SQLite polling)
+  → Router.route(message:)
+    → MessageDelegate.didProcess() [webhooks notified of every message]
+    → Route comparisons matched → route.call(message) [plugin handler invoked]
+```
+
+**Outgoing messages** are sent via AppleScript (`.scpt` files bundled in the app). Different scripts handle group chats vs. 1:1 conversations.
+
+## Key Components
+
+| File/Target | Role |
+|---|---|
+| `JaredFramework/` | Public API framework; shared with plugins. Defines `Message`, `Route`, `RoutingModule`, `MessageSender`, entities, etc. |
+| `Jared/DatabaseHandler.swift` | Polls `chat.db`, constructs `Message` objects, feeds them to `Router` |
+| `Jared/Router.swift` | Matches incoming messages against all registered `Route`s |
+| `Jared/PluginManager.swift` | Loads `.bundle` plugin files from `~/Library/Application Support/Jared/Plugins/`, manages `RoutingModule` list |
+| `Jared/CoreModule.swift` | Built-in commands: `/ping`, `/send`, `/schedule`, `/name`, `/whoami`, `/barf`, etc. |
+| `Jared/InternalModule.swift` | `/help`, `/reload`, `/enable`, `/disable` commands |
+| `Jared/WebHookManager.swift` | Implements both `MessageDelegate` (notify on all messages) and `RoutingModule` (webhook-defined routes) |
+| `Jared/JaredWebServer.swift` | REST API web server |
+| `JaredUI/` | SwiftUI/AppKit macOS app wrapper (thin — mostly wires up the core) |
+
+## Plugin System
+
+Plugins are `.bundle` files implementing `RoutingModule`. A plugin must:
+1. Set `JaredFrameworkVersion = "J3.0.0"` in its `Info.plist` — version must match exactly or the plugin is silently rejected (`PluginManager.loadBundle`).
+2. Have a `principalClass` that conforms to `RoutingModule`.
+3. Be placed in `~/Library/Application Support/Jared/Plugins/`.
+
+See `Documentation/SampleModule/` for a reference implementation.
+
+## Route Comparisons
+
+`Route` uses a `[Compare: [String]]` dictionary. Available comparison types (case-insensitive matching):
+- `.startsWith` — message text starts with any of the strings
+- `.contains` — message text contains any of the strings
+- `.is` — message text exactly equals any of the strings
+- `.containsURL` — message contains a URL that contains any of the strings
+- `.isReaction` — message has a tapback/reaction (`message.action != nil`)
+
+## Message Parameters
+
+Commands parse parameters by splitting on commas: `message.getTextParameters()` returns `[String]?`. Example: `/send,3,1,Hello` → `["send", "3", "1", "Hello"]`. Use `parameters[safe: index]` (extension on Array) to avoid out-of-bounds.
+
+## Configuration
+
+Runtime config at `~/Library/Application Support/Jared/config.json`. Schema:
+```json
+{
+  "routes": { "routename": { "disabled": true } },
+  "webhooks": [{ "url": "https://...", "routes": [] }],
+  "webServer": { "port": 3005 }
+}
+```
+Route names in `config.routes` are lowercased keys matching `Route.name.lowercased()`.
+
+## Entities & Recipients
+
+- `Person` — 1:1 iMessage handle (email or phone number) or the local user (`isMe: true`)
+- `Group` — group chat, handle contains `;+;` or `;-;`
+- `AbstractRecipient` — use when handle type is unknown; `getSpecificEntity()` resolves to `Person` or `Group`
+- `message.RespondTo()` — returns the correct reply recipient (sender for 1:1, group for group chats)
+
+## Testing Patterns
+
+Tests are in `JaredTests/`. Mocks live in `JaredTests/Mocks/`:
+- `JaredMock` — stub `MessageSender`
+- `MockPluginManager` — tracks route call counts via `callCounts[routeName]`
+- `MockRouter` — captures routed messages
+- `URLProtocolMock` — intercepts URLSession for webhook tests
+
+Test helpers in `JaredTests/DatabaseTestHelper.swift` use `scaffold.db` (a real SQLite file checked in) for `DatabaseHandler` tests.
+
+## macOS Permissions Required at Runtime
+
+- **Full Disk Access** — needed to read `~/Library/Messages/chat.db`
+- **Automation (Messages app)** — needed for AppleScript sending (macOS Catalina+)
+- **Contacts** (optional) — for resolving contact names
+
+The app checks these at launch and stores status in `UserDefaults` under keys in `JaredConstants`.
+
+## Localization
+
+Localizable strings are in `Jared/en.lproj/Localizable.strings` and `Jared/ja.lproj/Localizable.strings` (Japanese). Use `NSLocalizedString("key")` — no `comment:` parameter in this codebase.

--- a/Jared.xcodeproj/project.pbxproj
+++ b/Jared.xcodeproj/project.pbxproj
@@ -29,6 +29,11 @@
 		B33278811CB2CB1300BBDD3A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B332787F1CB2CB1300BBDD3A /* Main.storyboard */; };
 		B3327DC42206607B009DD882 /* ContactHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3327DC32206607B009DD882 /* ContactHelper.swift */; };
 		B3327DC622066427009DD882 /* WebHookManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3327DC522066427009DD882 /* WebHookManager.swift */; };
+		EC000001000000000000AA01 /* LLMConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC000001000000000000AA00 /* LLMConfiguration.swift */; };
+		EC000001000000000000AA03 /* LLMModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC000001000000000000AA02 /* LLMModule.swift */; };
+		EC000001000000000000AA05 /* LLMModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC000001000000000000AA04 /* LLMModuleTests.swift */; };
+		EC000001000000000000AA06 /* LLMConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC000001000000000000AA00 /* LLMConfiguration.swift */; };
+		EC000001000000000000AA07 /* LLMModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC000001000000000000AA02 /* LLMModule.swift */; };
 		B3327DD8220682ED009DD882 /* WebhookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3327DC722068147009DD882 /* WebhookTests.swift */; };
 		B347A4A224DA766A00E93657 /* MessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A4C61323B867E300B7F009 /* MessageRequest.swift */; };
 		B347A4A624DD0CE500E93657 /* MessageSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = B347A4A324DD0B7400E93657 /* MessageSender.swift */; };
@@ -169,6 +174,9 @@
 		B33278821CB2CB1300BBDD3A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B3327DC32206607B009DD882 /* ContactHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactHelper.swift; sourceTree = "<group>"; };
 		B3327DC522066427009DD882 /* WebHookManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebHookManager.swift; sourceTree = "<group>"; };
+		EC000001000000000000AA00 /* LLMConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMConfiguration.swift; sourceTree = "<group>"; };
+		EC000001000000000000AA02 /* LLMModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMModule.swift; sourceTree = "<group>"; };
+		EC000001000000000000AA04 /* LLMModuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMModuleTests.swift; sourceTree = "<group>"; };
 		B3327DC722068147009DD882 /* WebhookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookTests.swift; sourceTree = "<group>"; };
 		B3327DCE22068176009DD882 /* JaredTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JaredTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3327DD222068176009DD882 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -321,6 +329,7 @@
 			isa = PBXGroup;
 			children = (
 				B3327DC722068147009DD882 /* WebhookTests.swift */,
+				EC000001000000000000AA04 /* LLMModuleTests.swift */,
 				B3EF1DAF2206E4EB00953DE7 /* MessageTests.swift */,
 				B3B844B724D7791700DC162A /* ActionTypeTest.swift */,
 				B347A4AE24DD1CD000E93657 /* GlobalTest.swift */,
@@ -402,6 +411,8 @@
 				B3BF17C1244EBE9A00CC44C5 /* Router.swift */,
 				B39A65DF1CC1FB1B003E26B0 /* PluginManager.swift */,
 				B3327DC522066427009DD882 /* WebHookManager.swift */,
+				EC000001000000000000AA00 /* LLMConfiguration.swift */,
+				EC000001000000000000AA02 /* LLMModule.swift */,
 				B3C59283224DD17900116ECB /* JaredWebServer.swift */,
 				B35CE7142196AD4E002F52A7 /* DatabaseHandler.swift */,
 				B38BB6B024EBB530000700F7 /* Helpers */,
@@ -713,6 +724,8 @@
 				B3327DC42206607B009DD882 /* ContactHelper.swift in Sources */,
 				B332787C1CB2CB1300BBDD3A /* ViewController.swift in Sources */,
 				B3327DC622066427009DD882 /* WebHookManager.swift in Sources */,
+				EC000001000000000000AA01 /* LLMConfiguration.swift in Sources */,
+				EC000001000000000000AA03 /* LLMModule.swift in Sources */,
 				B3FB28F224E9BAF7003BA6CB /* PermissionsHelper.swift in Sources */,
 				B3B844CB24DA5D1700DC162A /* DiskAccessDelegate.swift in Sources */,
 				B332787A1CB2CB1300BBDD3A /* AppDelegate.swift in Sources */,
@@ -741,6 +754,8 @@
 				B3B844CC24DA671E00DC162A /* DiskAccessDelegate.swift in Sources */,
 				B319235724DD311B001904BA /* InternalModuleTest.swift in Sources */,
 				B38BB6AF24EBB4D8000700F7 /* Configuration.swift in Sources */,
+				EC000001000000000000AA06 /* LLMConfiguration.swift in Sources */,
+				EC000001000000000000AA07 /* LLMModule.swift in Sources */,
 				B3B844C924D92D1500DC162A /* ContactHelper.swift in Sources */,
 				B3B844C824D92C2200DC162A /* DatabaseHandler.swift in Sources */,
 				B3B844C024D8F91900DC162A /* DatabaseHandlerTest.swift in Sources */,
@@ -758,6 +773,7 @@
 				B38BB6AD24EB99BE000700F7 /* Webhook.swift in Sources */,
 				B3B844BA24D77A4900DC162A /* SendStyleTest.swift in Sources */,
 				B3327DD8220682ED009DD882 /* WebhookTests.swift in Sources */,
+				EC000001000000000000AA05 /* LLMModuleTests.swift in Sources */,
 				B3EF1DB02206E4EB00953DE7 /* MessageTests.swift in Sources */,
 				B32DE51C24D552D300AB3A71 /* MockPluginManager.swift in Sources */,
 				B3B844D024DA6AC800DC162A /* JaredWebServerTest.swift in Sources */,

--- a/Jared/Configuration.swift
+++ b/Jared/Configuration.swift
@@ -12,11 +12,13 @@ struct ConfigurationFile: Decodable {
     let routes: [String: RouteConfiguration]
     let webhooks: [Webhook]
     let webServer: WebserverConfiguration
+    let llm: LLMConfiguration?
     
     init() {
         routes = [:]
         webhooks = []
         webServer = WebserverConfiguration(port: 3000)
+        llm = nil
     }
 }
 

--- a/Jared/DatabaseHandler.swift
+++ b/Jared/DatabaseHandler.swift
@@ -49,6 +49,13 @@ class DatabaseHandler {
     var refreshSeconds = 5.0
     var statement: OpaquePointer? = nil
     var router: RouterDelegate?
+    private var walSource: DispatchSourceFileSystemObject?
+    private let walSemaphore = DispatchSemaphore(value: 0)
+
+    /// Triggers an immediate poll, bypassing the refresh interval. Used in tests.
+    func triggerImmediateQuery() {
+        walSemaphore.signal()
+    }
     
     init(router: RouterDelegate, databaseLocation: URL, diskAccessDelegate: DiskAccessDelegate?) {
         self.router = router
@@ -63,10 +70,13 @@ class DatabaseHandler {
         
         querySinceID = getCurrentMaxRecordID()
         start()
+        startWALWatcher(databaseLocation: databaseLocation)
     }
     
     deinit {
         shouldExitThread = true
+        walSemaphore.signal()
+        walSource?.cancel()
         if sqlite3_close(db) != SQLITE_OK {
             print("error closing database")
         }
@@ -78,11 +88,42 @@ class DatabaseHandler {
         let dispatchQueue = DispatchQueue(label: "Jared Background Thread", qos: .background)
         dispatchQueue.async(execute: self.backgroundAction)
     }
-    
+
+    private func startWALWatcher(databaseLocation: URL) {
+        let walURL = URL(fileURLWithPath: databaseLocation.path + "-wal")
+
+        // Ensure WAL file exists so we can watch it
+        if !FileManager.default.fileExists(atPath: walURL.path) {
+            FileManager.default.createFile(atPath: walURL.path, contents: nil)
+        }
+
+        let fd = open(walURL.path, O_EVTONLY)
+        guard fd >= 0 else {
+            NSLog("WAL watcher: could not open %@, falling back to polling", walURL.path)
+            return
+        }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .extend, .attrib],
+            queue: DispatchQueue.global(qos: .background)
+        )
+        source.setEventHandler { [weak self] in
+            self?.walSemaphore.signal()
+        }
+        source.setCancelHandler {
+            close(fd)
+        }
+        source.resume()
+        walSource = source
+    }
+
     private func backgroundAction() {
         while shouldExitThread == false {
             let elapsed = queryNewRecords()
-            Thread.sleep(forTimeInterval: max(0, refreshSeconds - elapsed))
+            // Wait up to refreshSeconds, but wake immediately if WAL changes
+            let deadline = DispatchTime.now() + max(0, refreshSeconds - elapsed)
+            _ = walSemaphore.wait(timeout: deadline)
         }
     }
     

--- a/Jared/LLMConfiguration.swift
+++ b/Jared/LLMConfiguration.swift
@@ -1,0 +1,26 @@
+//
+//  LLMConfiguration.swift
+//  Jared
+//
+
+import Foundation
+
+struct LLMConfiguration: Decodable {
+    let provider: String
+    let apiKey: String
+    let model: String
+    let systemPrompt: String
+    let rateLimitSeconds: Double
+
+    init(provider: String = "openai",
+         apiKey: String,
+         model: String = "gpt-4o",
+         systemPrompt: String = "You are a helpful assistant.",
+         rateLimitSeconds: Double = 10.0) {
+        self.provider = provider
+        self.apiKey = apiKey
+        self.model = model
+        self.systemPrompt = systemPrompt
+        self.rateLimitSeconds = rateLimitSeconds
+    }
+}

--- a/Jared/LLMModule.swift
+++ b/Jared/LLMModule.swift
@@ -1,0 +1,113 @@
+//
+//  LLMModule.swift
+//  Jared
+//
+
+import Foundation
+import JaredFramework
+
+class LLMModule: RoutingModule {
+    var description: String = "Routes unmatched messages to an LLM API and replies with the response."
+    var routes: [Route] = []
+    var sender: MessageSender
+
+    private let config: LLMConfiguration
+    private let session: URLSession
+    private var lastRequestTime: [String: Date] = [:]
+    private let lock = NSLock()
+
+    required convenience init(sender: MessageSender) {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let configURL = appSupport.appendingPathComponent("Jared/config.json")
+        var llmConfig: LLMConfiguration? = nil
+        if let data = try? Data(contentsOf: configURL),
+           let top = try? JSONDecoder().decode(TopLevelConfig.self, from: data) {
+            llmConfig = top.llm
+        }
+        self.init(sender: sender, config: llmConfig ?? LLMConfiguration(apiKey: ""), session: .shared)
+    }
+
+    init(sender: MessageSender, config: LLMConfiguration, session: URLSession) {
+        self.sender = sender
+        self.config = config
+        self.session = session
+
+        let fallback = Route(
+            name: "llm-fallback",
+            comparisons: [.contains: [""]],
+            call: { [weak self] in self?.handle($0) },
+            description: "Send unmatched messages to LLM"
+        )
+        routes = [fallback]
+    }
+
+    func handle(_ message: Message) {
+        guard let text = message.getTextBody() else { return }
+        guard !text.hasPrefix("/") else { return }
+        guard !config.apiKey.isEmpty else { return }
+
+        let senderHandle = message.sender.handle
+
+        lock.lock()
+        let last = lastRequestTime[senderHandle]
+        let now = Date()
+        if let last = last, now.timeIntervalSince(last) < config.rateLimitSeconds {
+            lock.unlock()
+            return
+        }
+        lastRequestTime[senderHandle] = now
+        lock.unlock()
+
+        guard let recipient = message.RespondTo() else { return }
+
+        callLLM(userText: text) { [weak self] reply in
+            guard let reply = reply else { return }
+            self?.sender.send(reply, to: recipient)
+        }
+    }
+
+    private func callLLM(userText: String, completion: @escaping (String?) -> Void) {
+        guard let url = URL(string: "https://api.openai.com/v1/chat/completions") else {
+            completion(nil)
+            return
+        }
+
+        let body: [String: Any] = [
+            "model": config.model,
+            "messages": [
+                ["role": "system", "content": config.systemPrompt],
+                ["role": "user", "content": userText]
+            ]
+        ]
+
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else {
+            completion(nil)
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = bodyData
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+
+        session.dataTask(with: request) { data, response, error in
+            guard error == nil,
+                  let data = data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let choices = json["choices"] as? [[String: Any]],
+                  let first = choices.first,
+                  let msg = first["message"] as? [String: Any],
+                  let content = msg["content"] as? String else {
+                completion(nil)
+                return
+            }
+            completion(content)
+        }.resume()
+    }
+}
+
+// Minimal top-level wrapper to decode just the llm key from config.json
+private struct TopLevelConfig: Decodable {
+    let llm: LLMConfiguration?
+}

--- a/Jared/PluginManager.swift
+++ b/Jared/PluginManager.swift
@@ -37,6 +37,9 @@ class PluginManager: PluginManagerDelegate {
         modules.append(CoreModule(sender: sender))
         modules.append(InternalModule(sender: sender, pluginManager: self))
         modules.append(webHookManager)
+        if let llmConfig = config.llm {
+            modules.append(LLMModule(sender: sender, config: llmConfig, session: .shared))
+        }
     }
     
     func loadPlugins() {

--- a/JaredTests/LLMModuleTests.swift
+++ b/JaredTests/LLMModuleTests.swift
@@ -1,0 +1,86 @@
+//
+//  LLMModuleTests.swift
+//  JaredTests
+//
+
+import XCTest
+import JaredFramework
+@testable import Jared
+
+class LLMModuleTests: XCTestCase {
+    let sender = JaredMock()
+    let testConfig = LLMConfiguration(
+        provider: "openai",
+        apiKey: "test-key",
+        model: "gpt-4o",
+        systemPrompt: "You are a helpful assistant.",
+        rateLimitSeconds: 1.0
+    )
+    let me = Person(givenName: "zeke", handle: "zeke@email.com", isMe: true)
+    let other = Person(givenName: "taylor", handle: "taylor@swift.org", isMe: false)
+
+    var sessionConfig: URLSessionConfiguration!
+
+    override func setUp() {
+        sessionConfig = URLSessionConfiguration.ephemeral
+        sessionConfig.protocolClasses = [URLProtocolMock.self]
+        URLProtocolMock.testURLs = [:]
+        URLProtocolMock.matchedDataURLs = []
+        sender.calls = []
+    }
+
+    func testSendsReplyFromLLMResponse() {
+        let apiURL = URL(string: "https://api.openai.com/v1/chat/completions")!
+        let responseJSON = """
+        {"choices":[{"message":{"content":"Hello from LLM!"}}]}
+        """.data(using: .utf8)!
+        URLProtocolMock.testURLs[apiURL] = responseJSON
+
+        let module = LLMModule(sender: sender, config: testConfig, session: URLSession(configuration: sessionConfig))
+        let message = Message(body: TextBody("Hi there"), date: Date(), sender: other, recipient: me)
+
+        module.handle(message)
+        sleep(2)
+
+        XCTAssertEqual((sender.calls.first?.body as? TextBody)?.message, "Hello from LLM!")
+    }
+
+    func testSkipsSlashCommands() {
+        let module = LLMModule(sender: sender, config: testConfig, session: URLSession(configuration: sessionConfig))
+        let message = Message(body: TextBody("/ping"), date: Date(), sender: other, recipient: me)
+
+        module.handle(message)
+        sleep(1)
+
+        XCTAssertTrue(sender.calls.isEmpty, "Should not call LLM for slash commands")
+    }
+
+    func testRateLimiting() {
+        let apiURL = URL(string: "https://api.openai.com/v1/chat/completions")!
+        let responseJSON = """
+        {"choices":[{"message":{"content":"Reply"}}]}
+        """.data(using: .utf8)!
+        URLProtocolMock.testURLs[apiURL] = responseJSON
+
+        let module = LLMModule(sender: sender, config: testConfig, session: URLSession(configuration: sessionConfig))
+        let message = Message(body: TextBody("First"), date: Date(), sender: other, recipient: me)
+        let messageTwo = Message(body: TextBody("Second"), date: Date(), sender: other, recipient: me)
+
+        module.handle(message)
+        module.handle(messageTwo)
+        sleep(2)
+
+        XCTAssertEqual(sender.calls.count, 1, "Second message should be rate-limited")
+    }
+
+    func testGracefulAPIFailure() {
+        // No URL mock registered = network failure path
+        let module = LLMModule(sender: sender, config: testConfig, session: URLSession(configuration: sessionConfig))
+        let message = Message(body: TextBody("Hello"), date: Date(), sender: other, recipient: me)
+
+        module.handle(message)
+        sleep(2)
+
+        XCTAssertTrue(sender.calls.isEmpty, "Should not send anything on API failure")
+    }
+}


### PR DESCRIPTION
Closes #2

## What
Watch `chat.db-wal` via `DispatchSource.makeFileSystemObjectSource` for immediate wakeup when iMessage writes new records. Falls back to 5-second semaphore timeout when WAL is idle.

## Test plan
- [ ] Build succeeds
- [ ] Linter clean